### PR TITLE
cprof_encode_text: fix wrong pointer assignment

### DIFF
--- a/src/cprof_encode_text.c
+++ b/src/cprof_encode_text.c
@@ -1909,7 +1909,7 @@ static int encode_cprof_resource_profiles(
                 struct cprof_resource_profiles *instance) {
     int result;
     struct cfl_list             *iterator;
-    struct cprof_scope_profile *scope_profile;
+    struct cprof_scope_profiles *scope_profiles;
 
     result = encode_string(context,
                             CFL_TRUE,
@@ -1958,11 +1958,11 @@ static int encode_cprof_resource_profiles(
 
         cfl_list_foreach(iterator,
                          &instance->scope_profiles) {
-            scope_profile = cfl_list_entry(
+            scope_profiles = cfl_list_entry(
                                 iterator,
                                 struct cprof_scope_profiles, _head);
 
-            result = encode_cprof_scope_profiles(context, scope_profile);
+            result = encode_cprof_scope_profiles(context, scope_profiles);
 
             if (result != CPROF_ENCODE_TEXT_SUCCESS) {
                 return result;


### PR DESCRIPTION
The wrong struct types were used. Typo?

```
/home/thomas/br-test-pkg/bootlin-armv7-glibc/build/fluent-bit-3.2.0/lib/cprofiles/src/cprof_profile.c: In function ‘cprof_profile_destroy’: /home/thomas/br-test-pkg/bootlin-armv7-glibc/build/fluent-bit-3.2.0/lib/cprofiles/src/cprof_profile.c:160:18: error: assignment to ‘struct cprof_mapping *’ from incompatible pointer type ‘struct cprof_location *’ [-Wincompatible-pointer-types]
  160 |         location = cfl_list_entry(iterator,
      |                  ^
/home/thomas/br-test-pkg/bootlin-armv7-glibc/build/fluent-bit-3.2.0/lib/cprofiles/src/cprof_profile.c:166:32: error: passing argument 1 of ‘cprof_location_destroy’ from incompatible pointer type [-Wincompatible-pointer-types]
  166 |         cprof_location_destroy(location);
      |                                ^~~~~~~~
      |                                |
      |                                struct cprof_mapping *
In file included from /home/thomas/br-test-pkg/bootlin-armv7-glibc/build/fluent-bit-3.2.0/lib/cprofiles/src/cprof_profile.c:21:
/home/thomas/br-test-pkg/bootlin-armv7-glibc/build/fluent-bit-3.2.0/lib/cprofiles/include/cprofiles/cprofiles.h:304:52: note: expected ‘struct cprof_location *’ but argument is of type ‘struct cprof_mapping *’
  304 | void cprof_location_destroy(struct cprof_location *instance);
      |                             ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
```

Fixes:
 - https://github.com/fluent/fluent-bit/issues/9601